### PR TITLE
fix: add type import keyword to conform to project tsconfig

### DIFF
--- a/db/migrations/20250207002521_create_users.ts
+++ b/db/migrations/20250207002521_create_users.ts
@@ -1,4 +1,4 @@
-import { Knex } from 'knex';
+import { type Knex } from 'knex';
 
 export async function up(knex: Knex): Promise<void> {
   return knex.schema.createTable('users', (table) => {

--- a/db/seeds/01-users.ts
+++ b/db/seeds/01-users.ts
@@ -1,4 +1,4 @@
-import { Knex } from 'knex';
+import { type Knex } from 'knex';
 
 export async function seed(knex: Knex): Promise<void> {
     await knex('users').del();

--- a/db/seeds/02-products.ts
+++ b/db/seeds/02-products.ts
@@ -1,4 +1,4 @@
-import { Knex } from 'knex';
+import { type Knex } from 'knex';
 
 export async function seed(knex: Knex): Promise<void> {
     await knex('products').del();


### PR DESCRIPTION
Added the `type` import keyword to migration and seeding files so Knex type import works correctly with the project's TSConfig setup.