### PR TITLE
Order upsert

### DIFF
--- a/src/actions/orders/create.ts
+++ b/src/actions/orders/create.ts
@@ -1,0 +1,102 @@
+import { FastifyReply, FastifyRequest } from 'fastify';
+import { transaction } from 'objection';
+import Order from '../../models/Order';
+import OrderItem from '../../models/OrderItem';
+import Product from '../../models/Product';
+import { OrderStatus } from '../../models/Order';
+import { ValidationError } from 'objection';
+
+interface Item {
+  product_id: number;
+  quantity: number;
+  discount?: number;
+}
+
+type Request = FastifyRequest<{ Body: { customer_id: number; items: Item[] } }>;
+
+export default async (
+  { body: { customer_id, items } }: Request,
+  reply: FastifyReply
+) => {
+
+  if (!customer_id || !items) {
+    return reply.code(400).send({ message: `customer_id and items are required` });
+  }
+
+  const trx = await transaction.start(Order.knex());
+
+  try {
+    const productIds = items.map(item => item.product_id);
+    const products = await Product.query(trx).findByIds(productIds);
+
+    const productMap = new Map(products.map(product => [product.id, product]));
+
+    let totalPaid = 0;
+    let totalDiscount = 0;
+
+    const orderItems = items.map(item => {
+      const product = productMap.get(item.product_id);
+
+      if (!product) {
+        return reply.code(400).send({ message: `Product with ID ${item.product_id} not found` });
+      }
+
+      const itemPaid = product.price * item.quantity;
+      const itemDiscount = item.discount ?? 0
+
+      totalPaid += itemPaid;
+      totalDiscount += itemDiscount;
+
+      return {
+        order_id: null,
+        product_id: item.product_id,
+        quantity: item.quantity,
+        tax: 0,
+        shipping: 0,
+        discount: itemDiscount,
+        paid: itemPaid,
+      };
+    });
+
+    const order = await Order.query(trx).insert({
+      customer_id,
+      total_paid: totalPaid,
+      total_tax: 0,
+      total_shipping: 0,
+      total_discount: totalDiscount,
+      status: OrderStatus.PaymentPending,
+    });
+
+    const orderItemsWithOrderId = orderItems.map(item => ({
+      ...item,
+      order_id: order.id,
+    }));
+
+    OrderItem.query(trx).insertGraph(orderItemsWithOrderId);
+    await trx.commit();
+
+    return reply.code(201).send({
+      id: order.id,
+      customer_id: order.customer_id,
+      total_paid: order.total_paid,
+      total_discount: order.total_discount,
+      status: order.status,
+      items: orderItemsWithOrderId
+    });
+  } catch (error) {
+    await trx.rollback();
+
+    if (error instanceof ValidationError) {
+      return reply.code(400).send({
+        message: 'Validation error',
+        error: {
+          name: error.name,
+          type: error.type,
+          data: error.data,
+        },
+      });
+    }
+
+    return reply.code(500).send({ message: 'Internal server error', error });
+  }
+};

--- a/src/actions/orders/create.ts
+++ b/src/actions/orders/create.ts
@@ -26,7 +26,7 @@ export default async (
   
   try {
     const { productMap } = await validateItems(items, trx);
-    const { orderItems, totalPaid, totalDiscount } = calculateTotals(items, productMap);
+    const { orderItems, totalPaid, totalDiscount } = calculateTotals(null, items, productMap);
 
     const order = await Order.query(trx).insert({
       customer_id,

--- a/src/actions/orders/create.ts
+++ b/src/actions/orders/create.ts
@@ -1,10 +1,9 @@
 import { FastifyReply, FastifyRequest } from 'fastify';
-import { transaction } from 'objection';
+import { transaction, ValidationError } from 'objection';
 import Order from '../../models/Order';
 import OrderItem from '../../models/OrderItem';
-import Product from '../../models/Product';
 import { OrderStatus } from '../../models/Order';
-import { ValidationError } from 'objection';
+import { calculateTotals, validateItems, ProductNotFoundError  } from '../../handlers/orderHandlers';
 
 interface Item {
   product_id: number;
@@ -24,39 +23,10 @@ export default async (
   }
 
   const trx = await transaction.start(Order.knex());
-
+  
   try {
-    const productIds = items.map(item => item.product_id);
-    const products = await Product.query(trx).findByIds(productIds);
-
-    const productMap = new Map(products.map(product => [product.id, product]));
-
-    let totalPaid = 0;
-    let totalDiscount = 0;
-
-    const orderItems = items.map(item => {
-      const product = productMap.get(item.product_id);
-
-      if (!product) {
-        return reply.code(400).send({ message: `Product with ID ${item.product_id} not found` });
-      }
-
-      const itemPaid = product.price * item.quantity;
-      const itemDiscount = item.discount ?? 0
-
-      totalPaid += itemPaid;
-      totalDiscount += itemDiscount;
-
-      return {
-        order_id: null,
-        product_id: item.product_id,
-        quantity: item.quantity,
-        tax: 0,
-        shipping: 0,
-        discount: itemDiscount,
-        paid: itemPaid,
-      };
-    });
+    const { productMap } = await validateItems(items, trx);
+    const { orderItems, totalPaid, totalDiscount } = calculateTotals(items, productMap);
 
     const order = await Order.query(trx).insert({
       customer_id,
@@ -72,7 +42,7 @@ export default async (
       order_id: order.id,
     }));
 
-    OrderItem.query(trx).insertGraph(orderItemsWithOrderId);
+    await OrderItem.query(trx).insertGraph(orderItemsWithOrderId);
     await trx.commit();
 
     return reply.code(201).send({
@@ -85,6 +55,10 @@ export default async (
     });
   } catch (error) {
     await trx.rollback();
+
+    if (error instanceof ProductNotFoundError) {
+      return reply.code(404).send({ message: error.message });
+    }
 
     if (error instanceof ValidationError) {
       return reply.code(400).send({

--- a/src/actions/orders/update.ts
+++ b/src/actions/orders/update.ts
@@ -1,0 +1,152 @@
+import { FastifyReply, FastifyRequest } from 'fastify';
+import { transaction } from 'objection';
+import Order from '../../models/Order';
+import OrderItem from '../../models/OrderItem';
+import Product from '../../models/Product';
+import { OrderStatus } from '../../models/Order';
+import { ValidationError } from 'objection';
+
+interface Item {
+    product_id: number;
+    quantity: number;
+    discount?: number;
+}
+
+type Request = FastifyRequest<{ Body: { id?: number; customer_id: number; status: OrderStatus; items: Item[] } }>;
+
+export default async (
+    { body: { id, customer_id, status, items } }: Request,
+    reply: FastifyReply
+) => {
+    if (!customer_id || !status) {
+        return reply.code(400).send({ message: `customer_id and status are required` });
+    }
+
+    const trx = await transaction.start(Order.knex());
+
+    try {
+        let order: Order;
+
+        if (id) {
+            const existingOrder = await Order.query(trx).findById(id);
+
+            if (!existingOrder) {
+                return reply.code(404).send({ message: `Order with ID ${id} not found` });
+            }
+
+            if (existingOrder.status !== OrderStatus.PaymentPending) {
+                return reply.code(400).send({ message: `Only orders with status 'payment_pending' can be updated` });
+            }
+
+            if (status) {
+                existingOrder.status = status;
+            }
+
+            order = existingOrder;
+        } else {
+            order = await Order.query(trx).insert({
+                customer_id,
+                total_paid: 0,
+                total_tax: 0,
+                total_shipping: 0,
+                total_discount: 0,
+                status: status || OrderStatus.PaymentPending,
+            });
+        }
+
+        const productIds = items.map((item: Item) => item.product_id);
+        const products = await Product.query(trx).findByIds(productIds);
+        const productMap = new Map(products.map(product => [product.id, product]));
+
+        let totalPaid = 0;
+        let totalDiscount = 0;
+
+        const orderItems = items.map((item) => {
+            const product = productMap.get(item.product_id);
+
+            if (!product) {
+                throw new Error(`Product with ID ${item.product_id} not found`);
+            }
+
+            const itemPaid = product.price * item.quantity;
+            const itemDiscount = item.discount ?? 0;
+
+            totalPaid += itemPaid;
+            totalDiscount += itemDiscount;
+
+            return {
+                order_id: order.id,
+                product_id: item.product_id,
+                quantity: item.quantity,
+                tax: 0,
+                shipping: 0,
+                discount: itemDiscount,
+                paid: itemPaid,
+            };
+        });
+
+        order.total_paid = totalPaid;
+        order.total_discount = totalDiscount;
+
+        await Order.query(trx).patchAndFetchById(order.id, {
+            total_paid: order.total_paid,
+            total_discount: order.total_discount,
+            status: order.status,
+        });
+
+        if (!items) {
+            await OrderItem.query(trx)
+                .delete()
+                .where('order_id', order.id)
+        } else {
+            const existingOrderItems = await OrderItem.query(trx).where('order_id', order.id);
+            const existingOrderItemMap = new Map(existingOrderItems.map(item => [item.product_id, item]));
+
+            for (const newItem of orderItems) {
+                const existingItem = existingOrderItemMap.get(newItem.product_id);
+
+                if (existingItem) {
+                    await OrderItem.query(trx)
+                        .patch({
+                            quantity: newItem.quantity,
+                            discount: newItem.discount,
+                            paid: newItem.paid,
+                        })
+                        .where('id', existingItem.id);
+                } else {
+                    await OrderItem.query(trx).insert(newItem);
+                }
+            }
+        }
+
+        await trx.commit();
+
+        return reply.code(200).send({
+            id: order.id,
+            customer_id: order.customer_id,
+            status: order.status,
+            items: orderItems,
+        });
+    } catch (error) {
+        await trx.rollback();
+
+        if (error instanceof Error) {
+            if (error.message.includes('Product with ID')) {
+                return reply.code(400).send({ message: error.message });
+            }
+        }
+
+        if (error instanceof ValidationError) {
+            return reply.code(400).send({
+                message: 'Validation error',
+                error: {
+                    name: error.name,
+                    type: error.type,
+                    data: error.data,
+                },
+            });
+        }
+
+        return reply.code(500).send({ message: 'Internal server error', error });
+    }
+};

--- a/src/handlers/orderHandlers.ts
+++ b/src/handlers/orderHandlers.ts
@@ -18,7 +18,7 @@ export async function validateItems(items: Item[], trx: any) {
   return { productMap };
 }
 
-export function calculateTotals(items: Item[], productMap: Map<number, Product>) {
+export function calculateTotals(order:any, items: Item[], productMap: Map<number, Product>) {
   let totalPaid = 0;
   let totalDiscount = 0;
 
@@ -36,7 +36,7 @@ export function calculateTotals(items: Item[], productMap: Map<number, Product>)
     totalDiscount += itemDiscount;
 
     return {
-      order_id: null,
+      order_id: order?.id || null,
       product_id: item.product_id,
       quantity: item.quantity,
       tax: 0,

--- a/src/handlers/orderHandlers.ts
+++ b/src/handlers/orderHandlers.ts
@@ -1,0 +1,50 @@
+import { transaction } from 'objection';
+import Product from '../models/Product';
+import { Item } from '../types/item'; 
+
+export class ProductNotFoundError extends Error {
+  constructor(productId: number) {
+    super(`Product with ID ${productId} not found`);
+    this.name = 'ProductNotFoundError';
+  }
+}
+
+export async function validateItems(items: Item[], trx: any) {
+  const productIds = items.map(item => item.product_id);
+  const products = await Product.query(trx).findByIds(productIds);
+
+  const productMap = new Map(products.map(product => [product.id, product]));
+
+  return { productMap };
+}
+
+export function calculateTotals(items: Item[], productMap: Map<number, Product>) {
+  let totalPaid = 0;
+  let totalDiscount = 0;
+
+  const orderItems = items.map(item => {
+    const product = productMap.get(item.product_id);
+
+    if (!product) {
+      throw new ProductNotFoundError(item.product_id);
+    }
+
+    const itemPaid = product.price * item.quantity;
+    const itemDiscount = item.discount ?? 0;
+
+    totalPaid += itemPaid;
+    totalDiscount += itemDiscount;
+
+    return {
+      order_id: null,
+      product_id: item.product_id,
+      quantity: item.quantity,
+      tax: 0,
+      shipping: 0,
+      discount: itemDiscount,
+      paid: itemPaid,
+    };
+  });
+
+  return { orderItems, totalPaid, totalDiscount };
+}

--- a/src/models/Order.ts
+++ b/src/models/Order.ts
@@ -61,7 +61,7 @@ class Order extends Model {
         modelClass: OrderItem,
         join: {
           from: 'orders.id',
-          to: 'order_items.order_id',
+          to: 'orders_items.order_id',
         }
       },
       products: {
@@ -70,8 +70,8 @@ class Order extends Model {
         join: {
           from: 'orders.id',
           through: {
-            from: 'order_items.order_id',
-            to: 'order_items.product_id',
+            from: 'orders_items.order_id',
+            to: 'orders_items.product_id',
           },
           to: 'products.id',
         }

--- a/src/models/OrderItem.ts
+++ b/src/models/OrderItem.ts
@@ -3,7 +3,7 @@ import Order from './Order';
 import Product from './Product';
 
 class OrderItem extends Model {
-  static tableName = 'order_items';
+  static tableName = 'orders_items';
 
   id!: number;
   order_id!: number;
@@ -41,7 +41,7 @@ class OrderItem extends Model {
         relation: Model.BelongsToOneRelation,
         modelClass: Order,
         join: {
-          from: 'order_items.order_id',
+          from: 'orders_items.order_id',
           to: 'orders.id',
         }
       },
@@ -50,7 +50,7 @@ class OrderItem extends Model {
         modelClass: Product,
         join: {
 
-          from: 'order_items.product_id',
+          from: 'orders_items.product_id',
           to: 'products.id',
         }
       }

--- a/src/models/Product.ts
+++ b/src/models/Product.ts
@@ -38,8 +38,8 @@ class Product extends Model {
         join: {
           from: 'products.id',
           through: {
-            from: 'order_items.product_id',
-            to: 'order_items.order_id',
+            from: 'orders_items.product_id',
+            to: 'orders_items.order_id',
           },
           to: 'orders.id',
         }

--- a/src/routes/order.ts
+++ b/src/routes/order.ts
@@ -1,0 +1,6 @@
+import { FastifyInstance } from 'fastify';
+import orderCreate from '../actions/orders/create';
+
+export default async function orderRoutes(server: FastifyInstance) {
+  server.post('/', orderCreate);
+}

--- a/src/routes/order.ts
+++ b/src/routes/order.ts
@@ -1,6 +1,8 @@
 import { FastifyInstance } from 'fastify';
 import orderCreate from '../actions/orders/create';
+import orderUpdate from '../actions/orders/update';
 
 export default async function orderRoutes(server: FastifyInstance) {
   server.post('/', orderCreate);
+  server.post('/update', orderUpdate);
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,11 +1,13 @@
 import fastify from 'fastify';
 import userRoutes from './routes/users';
 import productRoutes from './routes/products';
+import orderRoutes from './routes/order';
 
 const shouldLog = process.env.NODE_ENV !== 'test';
 const server = fastify({ logger: shouldLog });
 
 server.register(userRoutes, { prefix: '/users' });
 server.register(productRoutes, { prefix: '/products' });
+server.register(orderRoutes, { prefix: '/orders' });
 
 export default server;

--- a/src/types/item.ts
+++ b/src/types/item.ts
@@ -1,0 +1,5 @@
+export interface Item {
+    product_id: number;
+    quantity: number;
+    discount?: number;
+}

--- a/tests/requests/orders/create.test.ts
+++ b/tests/requests/orders/create.test.ts
@@ -1,59 +1,61 @@
 import 'tests/setup';
 import server from 'src/server';
-import Order from 'src/models/Order';
-import OrderItem from 'src/models/OrderItem';
-import Product from 'src/models/Product';
-import { LightMyRequestResponse } from 'fastify';
+import { createTestProducts } from '../../testSupport/productsFactory';
 
 describe('POST /orders', () => {
     describe('when the input is valid', () => {
-        it('when pass all the parameters', async () => {
-            const { product1Id, product2Id } = await createTestProducts();
+        describe('when creating an order with items', () => {
+            it('creates the order and returns 201', async () => {
+                const { product1Id, product2Id } = await createTestProducts(server);
 
-            const input = {
-                customer_id: 1,
-                items: [
-                    { product_id: product1Id, quantity: 2, discount: 3.98 },
-                    { product_id: product2Id, quantity: 1, discount: 0.99 }
-                ]
-            };
+                const input = {
+                    customer_id: 1,
+                    items: [
+                        { product_id: product1Id, quantity: 2, discount: 3.98 },
+                        { product_id: product2Id, quantity: 1, discount: 0.99 }
+                    ]
+                };
 
-            const response = await makeRequest(input);
+                const response = await makeRequest(input);
 
-            expect(response.statusCode).toBe(201);
-            expect(response.json()).toEqual(
-                expect.objectContaining({
-                    id: expect.any(Number),
-                    customer_id: input.customer_id,
-                    total_paid: 99,
-                    total_discount: 4.97,
-                    status: "payment_pending",
-                    items: expect.any(Object)
-                })
-            );
-        });
+                expect(response.statusCode).toBe(201);
+                expect(response.json()).toEqual(
+                    expect.objectContaining({
+                        id: expect.any(Number),
+                        customer_id: input.customer_id,
+                        total_paid: 99,
+                        total_discount: 4.97,
+                        status: "payment_pending",
+                        items: expect.any(Object)
+                    })
+                );
+            });
+        })
 
-        it('when a discount does not exist', async () => {
-            const { product1Id, product2Id } = await createTestProducts();
+        describe('when creating an order without discount items', () => {
+            it('creates the order and returns 201', async () => {
+                const { product1Id } = await createTestProducts(server);
 
-            const input = {
-                customer_id: 1,
-                items: [{ product_id: product1Id, quantity: 1 }]
-            };
+                const input = {
+                    customer_id: 1,
+                    items: [{ product_id: product1Id, quantity: 1 }]
+                };
 
-            const response = await makeRequest(input);
-            expect(response.statusCode).toBe(201);
-            expect(response.json()).toEqual(
-                expect.objectContaining({
-                    id: expect.any(Number),
-                    customer_id: input.customer_id,
-                    total_paid: 42.00,
-                    total_discount: 0,
-                    status: "payment_pending",
-                    items: expect.any(Object)
-                })
-            );
-        });
+                const response = await makeRequest(input);
+                expect(response.statusCode).toBe(201);
+                expect(response.json()).toEqual(
+                    expect.objectContaining({
+                        id: expect.any(Number),
+                        customer_id: input.customer_id,
+                        total_paid: 42.00,
+                        total_discount: 0,
+                        status: "payment_pending",
+                        items: expect.any(Object)
+                    })
+                );
+            });
+        })
+
     });
 
     describe('when a product does not exist', () => {
@@ -64,7 +66,7 @@ describe('POST /orders', () => {
 
         it('returns a bad request response', async () => {
             const response = await makeRequest(input);
-            expect(response.statusCode).toBe(400);
+            expect(response.statusCode).toBe(404);
             expect(response.json()).toEqual(
                 expect.objectContaining({
                     message: expect.stringContaining('Product with ID 999 not found'),
@@ -99,7 +101,7 @@ describe('POST /orders', () => {
         });
 
         it('returns 400 for wrong typeof input', async () => {
-            const { product1Id } = await createTestProducts();
+            const { product1Id } = await createTestProducts(server);
 
             const response = await makeRequest({
                 customer_id: 1,
@@ -136,42 +138,6 @@ describe('POST /orders', () => {
         server.inject({
             method: 'POST',
             url: '/orders',
-            body: input,
-        });
-
-    async function createTestProducts(): Promise<{ product1Id: number; product2Id: number }> {
-        const product1: Partial<Product> = {
-            name: 'Video Game',
-            sku: 'ATUSJN',
-            description: 'Video Game',
-            price: 42.0,
-            stock: 100,
-        };
-
-        const product2: Partial<Product> = {
-            name: 'Notebook',
-            sku: 'ASJDND',
-            description: 'Le novo',
-            price: 15.0,
-            stock: 200,
-        };
-
-        const response1 = await makeRequestProduct(product1);
-        const response2 = await makeRequestProduct(product2);
-
-        const jsonResponse1 = response1.json<Product>();
-        const jsonResponse2 = response2.json<Product>();
-
-        return {
-            product1Id: jsonResponse1.id,
-            product2Id: jsonResponse2.id,
-        };
-    }
-
-    const makeRequestProduct = (input: Partial<Product>) =>
-        server.inject({
-            method: 'POST',
-            url: '/products',
             body: input,
         });
 });

--- a/tests/requests/orders/create.test.ts
+++ b/tests/requests/orders/create.test.ts
@@ -1,0 +1,177 @@
+import 'tests/setup';
+import server from 'src/server';
+import Order from 'src/models/Order';
+import OrderItem from 'src/models/OrderItem';
+import Product from 'src/models/Product';
+import { LightMyRequestResponse } from 'fastify';
+
+describe('POST /orders', () => {
+    describe('when the input is valid', () => {
+        it('when pass all the parameters', async () => {
+            const { product1Id, product2Id } = await createTestProducts();
+
+            const input = {
+                customer_id: 1,
+                items: [
+                    { product_id: product1Id, quantity: 2, discount: 3.98 },
+                    { product_id: product2Id, quantity: 1, discount: 0.99 }
+                ]
+            };
+
+            const response = await makeRequest(input);
+
+            expect(response.statusCode).toBe(201);
+            expect(response.json()).toEqual(
+                expect.objectContaining({
+                    id: expect.any(Number),
+                    customer_id: input.customer_id,
+                    total_paid: 99,
+                    total_discount: 4.97,
+                    status: "payment_pending",
+                    items: expect.any(Object)
+                })
+            );
+        });
+
+        it('when a discount does not exist', async () => {
+            const { product1Id, product2Id } = await createTestProducts();
+
+            const input = {
+                customer_id: 1,
+                items: [{ product_id: product1Id, quantity: 1 }]
+            };
+
+            const response = await makeRequest(input);
+            expect(response.statusCode).toBe(201);
+            expect(response.json()).toEqual(
+                expect.objectContaining({
+                    id: expect.any(Number),
+                    customer_id: input.customer_id,
+                    total_paid: 42.00,
+                    total_discount: 0,
+                    status: "payment_pending",
+                    items: expect.any(Object)
+                })
+            );
+        });
+    });
+
+    describe('when a product does not exist', () => {
+        const input = {
+            customer_id: 1,
+            items: [{ product_id: 999, quantity: 1 }]
+        };
+
+        it('returns a bad request response', async () => {
+            const response = await makeRequest(input);
+            expect(response.statusCode).toBe(400);
+            expect(response.json()).toEqual(
+                expect.objectContaining({
+                    message: expect.stringContaining('Product with ID 999 not found'),
+                })
+            );
+        });
+    });
+
+    describe('when the input is invalid', () => {
+        it('returns 400 for the missing customer_id payload parameters', async () => {
+            const input = {
+                items: [{ product_id: 1, quantity: 1 }]
+            };
+
+            const response = await makeRequest(input);
+            expect(response.statusCode).toBe(400);
+            expect(response.json()).toEqual({
+                message: 'customer_id and items are required',
+            });
+        });
+
+        it('returns 400 for the missing items payload parameters', async () => {
+            const input = {
+                "customer_id": 1
+            };
+
+            const response = await makeRequest(input);
+            expect(response.statusCode).toBe(400);
+            expect(response.json()).toEqual({
+                message: 'customer_id and items are required',
+            });
+        });
+
+        it('returns 400 for wrong typeof input', async () => {
+            const { product1Id } = await createTestProducts();
+
+            const response = await makeRequest({
+                customer_id: 1,
+                items: [
+                    { product_id: product1Id, quantity: 2, discount: 'invalid' }
+                ]
+            });
+
+            expect(response.statusCode).toBe(400);
+            expect(response.json()).toEqual(
+                expect.objectContaining({
+                    message: 'Validation error',
+                    error: expect.objectContaining({
+                        name: 'ValidationError',
+                        type: 'ModelValidation',
+                        data: expect.objectContaining({
+                            "total_discount": expect.arrayContaining([
+                                expect.objectContaining({
+                                    message: 'must be number',
+                                    keyword: 'type',
+                                    params: expect.objectContaining({
+                                        type: 'number',
+                                    }),
+                                }),
+                            ]),
+                        }),
+                    }),
+                })
+            );
+        });
+    });
+
+    const makeRequest = async (input: any) =>
+        server.inject({
+            method: 'POST',
+            url: '/orders',
+            body: input,
+        });
+
+    async function createTestProducts(): Promise<{ product1Id: number; product2Id: number }> {
+        const product1: Partial<Product> = {
+            name: 'Video Game',
+            sku: 'ATUSJN',
+            description: 'Video Game',
+            price: 42.0,
+            stock: 100,
+        };
+
+        const product2: Partial<Product> = {
+            name: 'Notebook',
+            sku: 'ASJDND',
+            description: 'Le novo',
+            price: 15.0,
+            stock: 200,
+        };
+
+        const response1 = await makeRequestProduct(product1);
+        const response2 = await makeRequestProduct(product2);
+
+        const jsonResponse1 = response1.json<Product>();
+        const jsonResponse2 = response2.json<Product>();
+
+        return {
+            product1Id: jsonResponse1.id,
+            product2Id: jsonResponse2.id,
+        };
+    }
+
+    const makeRequestProduct = (input: Partial<Product>) =>
+        server.inject({
+            method: 'POST',
+            url: '/products',
+            body: input,
+        });
+});

--- a/tests/requests/orders/update.test.ts
+++ b/tests/requests/orders/update.test.ts
@@ -74,7 +74,7 @@ describe('POST /orders/update', () => {
 
             const response = await makeRequest(updateInput);
 
-            expect(response.statusCode).toBe(400);
+            expect(response.statusCode).toBe(404);
             expect(response.json()).toEqual(
                 expect.objectContaining({
                     message: expect.stringContaining('Product with ID 999 not found'),

--- a/tests/requests/orders/update.test.ts
+++ b/tests/requests/orders/update.test.ts
@@ -1,0 +1,167 @@
+import 'tests/setup';
+import server from 'src/server';
+import { createTestOrders } from '../../testSupport/ordersFactory';
+
+describe('POST /orders/update', () => {
+    describe('when the input is valid', () => {
+        describe('when updating an order with items', () => {
+            it('updates the order and returns 200', async () => {
+                const { order: existingOrder } = await createTestOrders(server);
+
+                const updateInput = {
+                    id: existingOrder.id,
+                    customer_id: existingOrder.customer_id,
+                    status: 'approved',
+                    items: [
+                        { product_id: existingOrder.items[0].product_id, quantity: 5, discount: 10.0 }
+                    ],
+                };
+
+                const response = await makeRequest(updateInput);
+
+                expect(response.statusCode).toBe(200);
+                expect(response.json()).toMatchObject({
+                    id: existingOrder.id,
+                    customer_id: updateInput.customer_id,
+                    status: updateInput.status,
+                    items: expect.arrayContaining([
+                        expect.objectContaining({
+                            product_id: updateInput.items[0].product_id,
+                            quantity: updateInput.items[0].quantity,
+                            discount: updateInput.items[0].discount,
+                        })
+                    ]),
+                });
+            });
+        });
+
+        describe('when updating an order without items', () => {
+            it('updates the order and returns 200', async () => {
+                const { order: existingOrder } = await createTestOrders(server);
+
+                const updateInput = {
+                    id: existingOrder.id,
+                    customer_id: existingOrder.customer_id,
+                    status: 'approved',
+                    items: []
+                };
+
+                const response = await makeRequest(updateInput);
+
+                expect(response.statusCode).toBe(200);
+                expect(response.json()).toMatchObject(
+                    expect.objectContaining({
+                        id: existingOrder.id,
+                        customer_id: updateInput.customer_id,
+                        status: updateInput.status,
+                        items: [], 
+                    })
+                );
+            });
+        });
+    });
+
+    describe('when the product does not exist', () => {
+        it('returns a bad request response', async () => {
+            const { order: existingOrder } = await createTestOrders(server);
+
+            const updateInput = {
+                id: existingOrder.id,
+                customer_id: existingOrder.customer_id,
+                status: 'approved',
+                items: [{ product_id: 999, quantity: 1 }],
+            };
+
+            const response = await makeRequest(updateInput);
+
+            expect(response.statusCode).toBe(400);
+            expect(response.json()).toEqual(
+                expect.objectContaining({
+                    message: expect.stringContaining('Product with ID 999 not found'),
+                })
+            );
+        });
+    });
+
+    describe('when the input is invalid', () => {
+        it('returns 400 for missing customer_id', async () => {
+            const { order: existingOrder } = await createTestOrders(server);
+
+            const updateInput = {
+                id: existingOrder.id,
+                status: 'approved',
+                items: [{ product_id: 1, quantity: 1 }],
+            };
+
+            const response = await makeRequest(updateInput);
+
+            expect(response.statusCode).toBe(400);
+            expect(response.json()).toEqual({
+                message: 'customer_id and status are required',
+            });
+        });
+
+        it('returns 400 for missing status', async () => {
+            const { order: existingOrder } = await createTestOrders(server);
+
+            const updateInput = {
+                id: existingOrder.id,
+                customer_id: existingOrder.customer_id,
+                items: [{ product_id: 1, quantity: 1 }],
+            };
+
+            const response = await makeRequest(updateInput);
+
+            expect(response.statusCode).toBe(400);
+            expect(response.json()).toEqual({
+                message: 'customer_id and status are required',
+            });
+        });
+    });
+
+    describe('when the order does not exist', () => {
+        it('returns 404 with an error message', async () => {
+            const updateInput = {
+                id: 999,
+                customer_id: 1,
+                status: 'approved',
+                items: [{ product_id: 1, quantity: 1 }],
+            };
+
+            const response = await makeRequest(updateInput);
+
+            expect(response.statusCode).toBe(404);
+            expect(response.json()).toEqual({
+                message: 'Order with ID 999 not found',
+            });
+        });
+    });
+
+    describe('when the order status does not allow updates', () => {
+        it('returns 400 with an error message', async () => {
+            const { order: existingOrder } = await createTestOrders(server);
+
+            const updateInput = {
+                id: existingOrder.id,
+                customer_id: existingOrder.customer_id,
+                status: 'asd',
+                items: [{ product_id: 1, quantity: 1 }],
+            };
+
+            const response = await makeRequest(updateInput);
+
+            expect(response.statusCode).toBe(400);
+            expect(response.json()).toEqual({
+                message: "Only orders with status 'payment_pending' can be updated",
+            });
+        });
+    });
+
+    const makeRequest = async (input: any) =>
+        server.inject({
+            method: 'POST',
+            url: '/orders/update',
+            body: input,
+        });
+
+});

--- a/tests/testSupport/ordersFactory.ts
+++ b/tests/testSupport/ordersFactory.ts
@@ -1,0 +1,27 @@
+import { FastifyInstance } from 'fastify';
+import { createTestProducts } from './productsFactory';
+
+export async function createTestOrders(server: FastifyInstance): Promise<{ order: any; statusCode: number }> {
+    const { product1Id, product2Id } = await createTestProducts(server);
+
+    const input = {
+        customer_id: 1,
+        items: [
+            { product_id: product1Id, quantity: 2, discount: 3.98 },
+            { product_id: product2Id, quantity: 1, discount: 0.99 }
+        ]
+    };
+
+    const response = await makeRequest(server, input);
+    const statusCode = response.statusCode;
+
+    const order = await response.json();
+    return { order, statusCode };
+}
+
+const makeRequest = (server: FastifyInstance, input: any) =>
+    server.inject({
+        method: 'POST',
+        url: '/orders',
+        payload: input,
+    });

--- a/tests/testSupport/productsFactory.ts
+++ b/tests/testSupport/productsFactory.ts
@@ -1,0 +1,38 @@
+import { FastifyInstance } from 'fastify';
+import Product from 'src/models/Product';
+
+export async function createTestProducts(server: FastifyInstance): Promise<{ product1Id: number; product2Id: number }> {
+    const product1: Partial<Product> = {
+        name: 'Video Game',
+        sku: 'ATUSJN',
+        description: 'Video Game',
+        price: 42.0,
+        stock: 100,
+    };
+
+    const product2: Partial<Product> = {
+        name: 'Notebook',
+        sku: 'ASJDND',
+        description: 'Le novo',
+        price: 15.0,
+        stock: 200,
+    };
+
+    const response1 = await makeRequestProduct(server, product1);
+    const response2 = await makeRequestProduct(server, product2);
+
+    const jsonResponse1 = await response1.json();
+    const jsonResponse2 = await response2.json();
+
+    return {
+        product1Id: jsonResponse1.id,
+        product2Id: jsonResponse2.id,
+    };
+}
+
+const makeRequestProduct = (server: FastifyInstance, input: Partial<Product>) =>
+    server.inject({
+        method: 'POST',
+        url: '/products',
+        payload: input,
+    });


### PR DESCRIPTION
### Task 2: Order Upsert Endpoint

Update the order creation endpoint from the previous task to allow orders to be inserted or updated (upsert). Only orders with status set 
to `payment_pending` can have items added, removed or theis quantities updated. Ensure the totals are updated accordingly.

- **Endpoint**: `POST /orders`
- **Payload**:
  ```json
  {
    "id": 101, // will update this order
    "customer_id": 1,
    "status": "approved", // changing its status
    "items": [
      {
        "product_id": 1,
        "quantity": 3,
        "discount": 3.98
      },
      {
        "product_id": 2,
        "quantity": 1,
        "discount": 0.99
      },
      { // and adding a new item
        "product_id": 3,
        "quantity": 1,
        "discount": 0.25
      }
    ]
  }
  ```
- **Payload Parameters**:
  - `id` (optional) the order id. If present, update the order, otherwise create a new one. 
  - `customer_id` (required)
  - `product_id` (required)
  - `quantity` (required)
  - `discount` (optional, defaults to 0) the total discount for the quantity provided, i.e, if the user is buying
  2 copies of the item and getting $1 discount on each, this field will be $2. No need to multiply discount by quantity.
- **Response**:
  ```json
  {
    "id": 101, // order id
    "customer_id": 1,
    "total_paid": 45.03,
    "total_discount": 4.97,
    "status": "approved",
    "items": [
      {
        "product_id": 1,
        "quantity": 2,
        "discount": 3.98
      },
      {
        "product_id": 2,
        "quantity": 1,
        "discount": 0.0
      }
    ]
  }
  ```